### PR TITLE
Prevent accessing email when auth user is null

### DIFF
--- a/src/Livewire/DeleteAccount.php
+++ b/src/Livewire/DeleteAccount.php
@@ -58,7 +58,7 @@ class DeleteAccount extends ProfileComponent
     {
         return TextInput::make('email')
             /** @phpstan-ignore-next-line */
-            ->label(fn () => __('profile-filament::pages/settings.delete_account.actions.delete.email_label', ['email' => Filament::auth()->user()->email]))
+            ->label(fn () => __('profile-filament::pages/settings.delete_account.actions.delete.email_label', ['email' => Filament::auth()->user()?->email]))
             ->required()
             ->email()
             ->rules([


### PR DESCRIPTION
As described in #9, there's an edge case where filament is trying to access the authenticated user from our callback function for setting the label on the email input. This will fail once the delete action is called since the authenticated user will be deleted.

Using php's null-safe operator on the authenticated user should prevent this from happening.