### PR TITLE
[feat]: Conditional Sudo Mode Enforcement

### DIFF
--- a/docs/auth/sudo.md
+++ b/docs/auth/sudo.md
@@ -47,7 +47,7 @@ ProfileFilamentPlugin::make()
 
 One thing to note: Some options are available for both the `MultiFactorChallengeProvider` and their `SudoChallengeProvider` counterparts; however, you will need to change those options on both instances when you do modify any of the options.
 
-> {tip} Don't forget to pass in an instance of the `SudoPasswordProvider` when adding in your other providers!
+> {tip} Remember to pass in an instance of the `SudoPasswordProvider` when adding in your other providers!
 
 > {tip} Any custom sudo challenge providers you create should use the same `id` as their `MultiFactorChallengeProvider` counterpart (if applicable).
 
@@ -514,3 +514,22 @@ use Rawilk\ProfileFilament\ProfileFilamentPlugin;
 ProfileFilamentPlugin::make()
     ->sudoMode(false)
 ```
+
+### Conditionally enabling sudo mode
+
+You may wish to only enable sudo mode checks for certain users or under certain conditions. You can use the `onlyChallengeSudoWhen()` method on the plugin to provide a callback that will be evaluated to determine if sudo mode should be enforced.
+
+```php
+use Rawilk\ProfileFilament\ProfileFilamentPlugin;
+
+ProfileFilamentPlugin::make()
+    ->onlyChallengeSudoWhen(function (): bool {
+        if (auth()->check()) {
+            return auth()->user()->isAdmin();
+        }
+        
+        return true;
+    })
+```
+
+> {note} When using a callback for `onlyChallengeSudoWhen()`, be aware that the authenticated user may not always be available, depending on where the check is being performed. You should account for this in your callback logic if necessary.

--- a/docs/auth/sudo.md
+++ b/docs/auth/sudo.md
@@ -515,7 +515,7 @@ ProfileFilamentPlugin::make()
     ->sudoMode(false)
 ```
 
-### Conditionally enabling sudo mode
+### Conditionally enforcing sudo mode
 
 You may wish to only enable sudo mode checks for certain users or under certain conditions. You can use the `onlyChallengeSudoWhen()` method on the plugin to provide a callback that will be evaluated to determine if sudo mode should be enforced.
 

--- a/src/Plugin/Concerns/HasSudoMode.php
+++ b/src/Plugin/Concerns/HasSudoMode.php
@@ -19,6 +19,8 @@ trait HasSudoMode
     /** @var array<string, SudoChallengeProvider> */
     protected ?array $sudoChallengeProviderCache = null;
 
+    protected ?Closure $onlyChallengeSudoWhenCallback = null;
+
     protected string $sudoChallengeRouteSlug = 'sessions/sudo-challenge';
 
     /** @var string|Closure|array<class-string, string>|null */
@@ -33,6 +35,16 @@ trait HasSudoMode
             : $providers;
 
         $this->sudoChallengeRouteAction = $routeChallengeAction;
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to determine if a sudo challenge should be shown.
+     */
+    public function onlyChallengeSudoWhen(?Closure $callback = null): static
+    {
+        $this->onlyChallengeSudoWhenCallback = $callback;
 
         return $this;
     }
@@ -90,6 +102,10 @@ trait HasSudoMode
 
     public function hasSudoMode(): bool
     {
+        if ($this->onlyChallengeSudoWhenCallback !== null && ! ($this->evaluate($this->onlyChallengeSudoWhenCallback))) {
+            return false;
+        }
+
         return ! empty($this->getSudoChallengeProviders());
     }
 }

--- a/src/Plugin/Concerns/HasSudoMode.php
+++ b/src/Plugin/Concerns/HasSudoMode.php
@@ -17,7 +17,7 @@ trait HasSudoMode
     protected array|SudoChallengeProvider|Closure|null $sudoChallengeProviders = null;
 
     /** @var array<string, SudoChallengeProvider> */
-    protected array $sudoChallengeProviderCache = [];
+    protected ?array $sudoChallengeProviderCache = null;
 
     protected string $sudoChallengeRouteSlug = 'sessions/sudo-challenge';
 
@@ -64,7 +64,7 @@ trait HasSudoMode
 
     public function getSudoChallengeProviders(): array
     {
-        if (! empty($this->sudoChallengeProviderCache)) {
+        if ($this->sudoChallengeProviderCache !== null) {
             return $this->sudoChallengeProviderCache;
         }
 

--- a/tests/Feature/ProfileFilamentPluginTest.php
+++ b/tests/Feature/ProfileFilamentPluginTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use Rawilk\ProfileFilament\Auth\Sudo\Webauthn\SudoWebauthnProvider;
 use Rawilk\ProfileFilament\ProfileFilamentPlugin;
+use Rawilk\ProfileFilament\Tests\TestSupport\Models\User;
+
+use function Pest\Laravel\be;
 
 beforeEach(function () {
     $this->plugin = ProfileFilamentPlugin::make();
@@ -32,5 +35,21 @@ describe('sudo mode', function () {
         $this->plugin->sudoMode(providers: false);
 
         expect($this->plugin->hasSudoMode())->toBeFalse();
+    });
+
+    it('can conditionally disable sudo mode checks with a callback', function () {
+        be($user = User::factory()->create());
+
+        $this->plugin->sudoMode(providers: null);
+
+        expect($this->plugin->hasSudoMode())->toBeTrue();
+
+        $this->plugin->onlyChallengeSudoWhen(fn (): bool => auth()->user()->isNot($user));
+
+        expect($this->plugin->hasSudoMode())->toBeFalse();
+
+        be(User::factory()->create());
+
+        expect($this->plugin->hasSudoMode())->toBeTrue();
     });
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -58,7 +58,7 @@ function enableSudoMode(?array $providers = null): void
         SudoPasswordProvider::make(),
     ];
 
-    (fn () => $this->sudoChallengeProviderCache = [])->call($plugin);
+    (fn () => $this->sudoChallengeProviderCache = null)->call($plugin);
 
     $plugin->sudoMode($providers);
 }


### PR DESCRIPTION
This PR adds a `onlyChallengeSudoWhen()` method to the plugin to allow more control over when sudo mode should be enforced on a panel. For example, you could only enforce sudo mode for admin users with this callback.

Since we check if sudo mode is enabled on the plugin for a panel in places like the routes file, any callback provided should first check if the authenticated user is present before performing any logic checks against the user.

```php
use Rawilk\ProfileFilament\ProfileFilamentPlugin;

ProfileFilamentPlugin::make()
    ->onlyChallengeSudoWhen(function (): bool {
        if (auth()->check()) {
            return auth()->user()->isAdmin();
        }
        
        return true;
    })
```