### PR TITLE
Set `key()` on `SudoChallengeActionForm` livewire component

### DIFF
--- a/src/Auth/Sudo/Actions/SudoChallengeAction.php
+++ b/src/Auth/Sudo/Actions/SudoChallengeAction.php
@@ -70,7 +70,7 @@ class SudoChallengeAction extends Action
                 HTML))
             ),
 
-            Livewire::make(SudoChallengeActionForm::class),
+            Livewire::make(SudoChallengeActionForm::class)->key('sudoChallengeActionForm'),
 
             Text::make(
                 new HtmlString(Blade::render(<<<'HTML'


### PR DESCRIPTION
This pull request adds a unique key to the `SudoChallengeActionForm` Livewire component initialization. It ensures proper reactivity and prevents potential rendering issues.